### PR TITLE
Feat/add dark mode support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@tailwindcss/forms": "^0.5.9",
     "driver.js": "^1.3.1",
+    "mode-watcher": "^0.5.1",
     "posthog-js": "^1.205.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       driver.js:
         specifier: ^1.3.1
         version: 1.3.1
+      mode-watcher:
+        specifier: ^0.5.1
+        version: 0.5.1(svelte@5.14.3)
       posthog-js:
         specifier: ^1.205.0
         version: 1.205.0
@@ -2030,6 +2033,11 @@ packages:
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+
+  mode-watcher@0.5.1:
+    resolution: {integrity: sha512-adEC6T7TMX/kzQlaO/MtiQOSFekZfQu4MC+lXyoceQG+U5sKpJWZ4yKXqw846ExIuWJgedkOIPqAYYRk/xHm+w==}
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.1
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -4899,6 +4907,10 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  mode-watcher@0.5.1(svelte@5.14.3):
+    dependencies:
+      svelte: 5.14.3
 
   mri@1.2.0: {}
 

--- a/src/lib/components/misc/changelog/changelog.svelte
+++ b/src/lib/components/misc/changelog/changelog.svelte
@@ -41,38 +41,34 @@
 </script>
 
 {#if currentVersion}
-	<div class="fixed bottom-4 z-50 w-full">
-		<div class="mx-auto max-w-[1700px] px-4">
-			<div class="flex justify-end">
-				<Dialog.Root bind:open>
-					<Dialog.Trigger>
-						{#snippet child()}
-							<Button
-								size="sm"
-								variant={hasNewVersion ? 'default' : 'secondary'}
-								onclick={openChangelog}
-								class="gap-2"
-							>
-								<span>Latest Updates</span>
-								{#if hasNewVersion}
-									<div class="relative mr-1">
-										<div class="absolute -right-1.5 -top-1 h-2 w-2">
-											<div
-												class="absolute h-full w-full animate-ping rounded-full bg-amber-400 opacity-75"
-											></div>
-											<div class="h-full w-full rounded-full bg-amber-400"></div>
-										</div>
-									</div>
-								{/if}
-							</Button>
-						{/snippet}
-					</Dialog.Trigger>
-					<Dialog.Content>
-						{@render changelogContent(currentVersion)}
-					</Dialog.Content>
-				</Dialog.Root>
-			</div>
-		</div>
+	<div class="flex justify-end">
+		<Dialog.Root bind:open>
+			<Dialog.Trigger>
+				{#snippet child()}
+					<Button
+						size="sm"
+						variant={hasNewVersion ? 'default' : 'secondary'}
+						onclick={openChangelog}
+						class="gap-2"
+					>
+						<span>Latest Updates</span>
+						{#if hasNewVersion}
+							<div class="relative mr-1">
+								<div class="absolute -right-1.5 -top-1 h-2 w-2">
+									<div
+										class="absolute h-full w-full animate-ping rounded-full bg-amber-400 opacity-75"
+									></div>
+									<div class="h-full w-full rounded-full bg-amber-400"></div>
+								</div>
+							</div>
+						{/if}
+					</Button>
+				{/snippet}
+			</Dialog.Trigger>
+			<Dialog.Content>
+				{@render changelogContent(currentVersion)}
+			</Dialog.Content>
+		</Dialog.Root>
 	</div>
 {/if}
 

--- a/src/lib/components/misc/toggle-theme.svelte
+++ b/src/lib/components/misc/toggle-theme.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { Moon, Sun } from "lucide-svelte";
+
+
+	import { Button } from "../ui/button";
+	import { toggleMode } from "mode-watcher";
+
+</script>
+
+<div class="flex justify-end my-3 gap-2">
+    <Button onclick={toggleMode} variant="outline" size="icon">
+        <Sun
+          class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
+        />
+        <Moon
+          class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
+        />
+        <span class="sr-only">Toggle theme</span>
+    </Button>
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { ModeWatcher } from "mode-watcher";
 	import { metrics } from '$lib/analytics';
 	import '../app.css';
 	import { AlertTriangle } from 'lucide-svelte';
@@ -18,6 +19,7 @@
 <svelte:window on:error={handleError} />
 
 <UltraWideJoke />
+<ModeWatcher />
 
 {#if error}
 	<div class="min-h-screen px-2 py-8 sm:px-4">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,7 @@
 		type CookieConsent
 	} from '$lib/types';
 	import { metrics, disposeAnalytics } from '$lib/analytics';
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy } from 'svelte';
 	import preferences from '$lib/stores/preferences';
 	import versionStore from '$lib/stores/versionStore.svelte';
 	import { changes } from '$lib/changes';
@@ -31,6 +31,9 @@
 	import { Button } from '$lib/components/ui/button';
 	import { showTour } from '$lib/tours';
 	import { TOURS } from '$lib/tours/types';
+	import { Moon, Sun } from 'lucide-svelte';
+	import { toggleMode } from 'mode-watcher';
+	import ToggleTheme from '$lib/components/misc/toggle-theme.svelte';
 
 	let innerWidth = $state(0);
 	// Taken from tailwind.config.ts
@@ -162,14 +165,20 @@
 
 <svelte:window bind:innerWidth />
 
-<Changelog
-	{changes}
-	lastSeenVersion={versionStore.lastSeenVersion}
-	onOpen={(seenVersion, isNewVersion) => {
-		versionStore.lastSeenVersion = seenVersion;
-		metrics.changelogOpened(seenVersion, isNewVersion);
-	}}
-/>
+
+<div class="fixed bottom-4 z-50 w-full">
+	<div class="mx-auto max-w-[1700px] px-4">
+		<ToggleTheme />
+		<Changelog
+			{changes}
+			lastSeenVersion={versionStore.lastSeenVersion}
+			onOpen={(seenVersion, isNewVersion) => {
+				versionStore.lastSeenVersion = seenVersion;
+				metrics.changelogOpened(seenVersion, isNewVersion);
+			}}
+		/>
+	</div>
+</div>
 <CookieBanner
 	onAccept={handleConsent}
 	showBanner={cookieConsent.isLoaded && cookieConsent.value.timestamp === null}


### PR DESCRIPTION
## Issue

#50

## Description

Implement dark mode support using:

- [x] Shadcn's theming system for consistent styling
- [x] ModeWatcher component for theme management
- [x] System preference detection
- [x] Local storage for persisting user preferences

## Screenshots

**Dark**
![image](https://github.com/user-attachments/assets/7744e1c8-59b0-4a29-9578-75faa33940f3)

**Light**
![image](https://github.com/user-attachments/assets/b46fb34a-d866-4646-a33f-da368a6f2923)
