### PR TITLE
Feat: add Region Filters in LocalStorage

### DIFF
--- a/e2e/main-flow.test.ts
+++ b/e2e/main-flow.test.ts
@@ -1055,14 +1055,14 @@ test.describe('Filter Regions', () => {
 		await pageIsReady(page);
 
 		// Verify Europe region is still selected
-		await expect(europeButton).toHaveAttribute('data-active', 'true');
+		await expect(europeButton).toHaveAttribute('data-selected', 'true');
 		const otherRegionButtons = await page
 			.getByTestId('regions-filter-list')
 			.getByRole('button')
 			.filter({ hasNotText: 'Europe' })
 			.all();
 		for (const button of otherRegionButtons) {
-			await expect(button).not.toHaveAttribute('data-active', 'true');
+			await expect(button).not.toHaveAttribute('data-selected', 'true');
 		}
 	});
 });

--- a/e2e/main-flow.test.ts
+++ b/e2e/main-flow.test.ts
@@ -1052,12 +1052,17 @@ test.describe('Filter Regions', () => {
 
 		// Reload page
 		await page.reload();
+		await pageIsReady(page);
 
 		// Verify Europe region is still selected
-		const selectedRegions = await page.evaluate(() => {
-			const regions = localStorage.getItem('carryfit_user_filter_regions');
-			return regions ? JSON.parse(regions) : [];
-		});
-		expect(selectedRegions).toContain('Europe');
+		await expect(europeButton).toHaveAttribute('data-active', 'true');
+		const otherRegionButtons = await page
+			.getByTestId('regions-filter-list')
+			.getByRole('button')
+			.filter({ hasNotText: 'Europe' })
+			.all();
+		for (const button of otherRegionButtons) {
+			await expect(button).not.toHaveAttribute('data-active', 'true');
+		}
 	});
 });

--- a/e2e/main-flow.test.ts
+++ b/e2e/main-flow.test.ts
@@ -43,30 +43,6 @@ test.describe('Allowance table interaction', () => {
 		await expect(page.getByRole('cell', { name: /Finnair/i })).toBeVisible();
 	});
 
-	test('should filter airlines by region', async ({ page }) => {
-		// Get initial number of rows
-		const initialRows = await page.getByRole('row').count();
-		expect(initialRows).toBeGreaterThan(0);
-
-		// Deselect all regions except one
-		const europeCheckbox = page.getByRole('button', { name: 'Europe' });
-		await page.getByText('Clear All').click();
-		await europeCheckbox.click();
-
-		// Wait for the table to be shown after filtering
-		await expect(page.getByRole('table')).toBeVisible();
-
-		// Get filtered number of rows and verify it's less than initial
-		const filteredRows = await page.getByRole('row').count();
-		expect(filteredRows).toBeLessThan(initialRows);
-
-		// Verify all visible airlines are from Europe
-		const regionCells = page.getByRole('cell', { name: 'Europe' });
-		const regionCount = await regionCells.count();
-		expect(regionCount).toBeGreaterThan(0);
-		expect(regionCount).toBe(filteredRows - 1);
-	});
-
 	test('should sort airlines correctly', async ({ page }) => {
 		// Test sorting by airline name
 		const airlineSortButton = page.getByRole('button', { name: /^Airline/ });
@@ -1044,7 +1020,7 @@ test.describe('Filter Regions', () => {
 		await preparePage(page, true);
 	});
 
-	test('should filter airlines by selected regions', async ({ page }) => {
+	test('should filter airlines by region', async ({ page }) => {
 		// Get initial number of rows
 		const initialRows = await page.getByRole('row').count();
 		expect(initialRows).toBeGreaterThan(0);
@@ -1069,39 +1045,19 @@ test.describe('Filter Regions', () => {
 	});
 
 	test('should persist selected regions across page reloads', async ({ page }) => {
-		// Deselect all regions except one
-		const europeCheckbox = page.getByRole('button', { name: 'Europe' });
+		// Select Europe region
+		const europeButton = page.getByRole('button', { name: 'Europe' });
 		await page.getByText('Clear All').click();
-		await europeCheckbox.click();
+		await europeButton.click();
 
 		// Reload page
 		await page.reload();
-		await expect(page.getByRole('table')).toBeVisible();
 
-		// Verify only Europe region is selected
-		const selectedRegions = await page.getByTestId('regions-filter-list').getByRole('button', { name: 'Europe' }).getAttribute('data-selected');
-		expect(selectedRegions).toBe('true');
-	});
-
-	test('should update region filters when favorites change', async ({ page }) => {
-		// Add one airline to favorites
-		const firstAirlineRow = page.getByRole('row').nth(1);
-		const region = await firstAirlineRow.getByTestId('region').textContent();
-		await firstAirlineRow.getByTestId('favorite-button').click();
-
-		// Enable favorites filter
-		await page.getByLabel('Favorites only').check();
-
-		// Verify region with favorite is enabled
-		const favoriteRegionButton = page
-			.getByTestId('regions-filter-list')
-			.getByRole('button', { name: region! });
-		await expect(favoriteRegionButton).not.toBeDisabled();
-
-		// Remove airline from favorites
-		await firstAirlineRow.getByTestId('favorite-button').click();
-
-		// Verify region is now disabled
-		await expect(favoriteRegionButton).toBeDisabled();
+		// Verify Europe region is still selected
+		const selectedRegions = await page.evaluate(() => {
+			const regions = localStorage.getItem('carryfit_user_filter_regions');
+			return regions ? JSON.parse(regions) : [];
+		});
+		expect(selectedRegions).toContain('Europe');
 	});
 });

--- a/src/lib/components/main/filters/allowance-filter.svelte
+++ b/src/lib/components/main/filters/allowance-filter.svelte
@@ -16,14 +16,14 @@
 		airlines: AirlineInfo[];
 		favoriteAirlines: string[];
 		filteredAirlines: AirlineInfo[];
-    filterRegions: string[];
+		filterRegions: string[];
 	}
 
 	let {
 		airlines,
 		favoriteAirlines = $bindable(),
 		filteredAirlines = $bindable(),
-    filterRegions = $bindable()
+		filterRegions = $bindable()
 	}: Props = $props();
 
 	let showFavoritesOnly = $state(false);
@@ -40,11 +40,11 @@
 	);
 
 	$effect(() => {
-    filteredAirlines = airlines
-      .filter((airline) => selectedRegions.has(airline.region))
-      .filter((airline) => !showFavoritesOnly || favoriteAirlinesSet.has(airline.airline));
-    filterRegions = Array.from(selectedRegions);
-  });
+		filteredAirlines = airlines
+			.filter((airline) => selectedRegions.has(airline.region))
+			.filter((airline) => !showFavoritesOnly || favoriteAirlinesSet.has(airline.airline));
+		filterRegions = Array.from(selectedRegions);
+	});
 
 	function isRegionAvailable(region: string): boolean {
 		return (

--- a/src/lib/components/main/filters/allowance-filter.svelte
+++ b/src/lib/components/main/filters/allowance-filter.svelte
@@ -16,12 +16,14 @@
 		airlines: AirlineInfo[];
 		favoriteAirlines: string[];
 		filteredAirlines: AirlineInfo[];
+    filterRegions: string[];
 	}
 
 	let {
 		airlines,
 		favoriteAirlines = $bindable(),
-		filteredAirlines = $bindable()
+		filteredAirlines = $bindable(),
+    filterRegions = $bindable()
 	}: Props = $props();
 
 	let showFavoritesOnly = $state(false);
@@ -31,17 +33,18 @@
 
 	const allRegions = [...new Set(airlines.map((airline) => airline.region))].sort();
 
-	let selectedRegions = $state(new Set(allRegions));
+	let selectedRegions = $state(new Set(filterRegions.length ? filterRegions : allRegions));
 
 	const availableSelectedRegions = $derived(
 		allRegions.filter((region) => selectedRegions.has(region) && isRegionAvailable(region))
 	);
 
 	$effect(() => {
-		filteredAirlines = airlines
-			.filter((airline) => selectedRegions.has(airline.region))
-			.filter((airline) => !showFavoritesOnly || favoriteAirlinesSet.has(airline.airline));
-	});
+    filteredAirlines = airlines
+      .filter((airline) => selectedRegions.has(airline.region))
+      .filter((airline) => !showFavoritesOnly || favoriteAirlinesSet.has(airline.airline));
+    filterRegions = Array.from(selectedRegions);
+  });
 
 	function isRegionAvailable(region: string): boolean {
 		return (

--- a/src/lib/components/main/filters/allowance-filter.svelte
+++ b/src/lib/components/main/filters/allowance-filter.svelte
@@ -131,6 +131,7 @@
 								variant={isSelected ? 'default' : 'outline'}
 								disabled={!isAvailable}
 								onclick={() => isAvailable && toggleRegion(region)}
+								data-selected={isSelected}
 							>
 								<span>{region}</span>
 								{#if isSelected && isAvailable}

--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -23,6 +23,17 @@ let favoriteAirlinesStore = createLocalStore<string[]>(
 	}
 );
 
+let filterResgionsStore = createLocalStore<string[]>(
+	'carryfit_user_filter_regions',
+	[],
+	(loaded, initial) => {
+		if (Array.isArray(loaded)) {
+			return loaded;
+		}
+		return initial;
+	}
+);
+
 export default {
 	get measurementSystem() {
 		return measurementSystemStore.value;
@@ -36,5 +47,12 @@ export default {
 	},
 	set favoriteAirlines(airlines: string[]) {
 		favoriteAirlinesStore.value = airlines;
+	},
+
+	get filterRegions() {
+		return filterResgionsStore.value;
+	},
+	set filterRegions(regions: string[]) {
+		filterResgionsStore.value = regions;
 	}
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -219,6 +219,7 @@
 					airlines={allAirlines}
 					bind:favoriteAirlines={preferences.favoriteAirlines}
 					bind:filteredAirlines
+					bind:filterRegions={preferences.filterRegions}
 				/>
 				<AllowanceTable
 					measurementSystem={preferences.measurementSystem}


### PR DESCRIPTION
### Issue
#59 

### Description

- Added region filters in `preferences.ts`.
- Updated logic in `allowance-filter.svelte` to persist region filters after reloading.
- Added end-to-end tests in `main-flow.test.ts` to verify the persistence and functionality of region filters.