### PR TITLE
[FEATURE] Migrate Stores to IndexedDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-storybook": "^0.11.2",
 		"eslint-plugin-svelte": "^2.36.0",
+		"fake-indexeddb": "^6.0.0",
 		"globals": "^15.0.0",
 		"jsdom": "^26.0.0",
 		"lucide-svelte": "^0.469.0",
@@ -62,6 +63,7 @@
 	},
 	"dependencies": {
 		"@tailwindcss/forms": "^0.5.9",
+		"dexie": "^4.0.11",
 		"driver.js": "^1.3.1",
 		"mode-watcher": "^0.5.1",
 		"posthog-js": "^1.205.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tailwindcss/forms':
         specifier: ^0.5.9
         version: 0.5.9(tailwindcss@3.4.17)
+      dexie:
+        specifier: ^4.0.11
+        version: 4.0.11
       driver.js:
         specifier: ^1.3.1
         version: 1.3.1
@@ -90,6 +93,9 @@ importers:
       eslint-plugin-svelte:
         specifier: ^2.36.0
         version: 2.46.1(eslint@9.17.0(jiti@1.21.7))(svelte@5.14.3)
+      fake-indexeddb:
+        specifier: ^6.0.0
+        version: 6.0.0
       globals:
         specifier: ^15.0.0
         version: 15.13.0
@@ -1380,6 +1386,9 @@ packages:
   devalue@5.1.1:
     resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
 
+  dexie@4.0.11:
+    resolution: {integrity: sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -1605,6 +1614,10 @@ packages:
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
     engines: {node: '>=12.0.0'}
+
+  fake-indexeddb@6.0.0:
+    resolution: {integrity: sha512-YEboHE5VfopUclOck7LncgIqskAqnv4q0EWbYCaxKKjAvO93c+TJIaBuGy8CBFdbg9nKdpN3AuPRwVBJ4k7NrQ==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4178,6 +4191,8 @@ snapshots:
 
   devalue@5.1.1: {}
 
+  dexie@4.0.11: {}
+
   didyoumean@1.2.2: {}
 
   dlv@1.1.3: {}
@@ -4508,6 +4523,8 @@ snapshots:
   esutils@2.0.3: {}
 
   expect-type@1.1.0: {}
+
+  fake-indexeddb@6.0.0: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/src/lib/storage/app-database.ts
+++ b/src/lib/storage/app-database.ts
@@ -1,0 +1,38 @@
+import Dexie, { type Table } from 'dexie';
+
+export class AppDatabase extends Dexie {
+	private tablesMap: { [key: string]: Table<any, string> } = {};
+	private currentVersion: number = 0;
+	private schema: { [key: string]: string } = {
+		migration: 'key' // Initial table for migration tracking
+	};
+
+	constructor() {
+		super('AppDatabase');
+
+		// Initial version
+		this.version(1).stores(this.schema);
+	}
+
+	// Register a new table based on key
+	registerTable<T>(key: string, initialSchema: string = 'id'): Table<T, string> {
+		if (!this.tablesMap[key]) {
+			this.currentVersion++;
+			this.schema[key] = initialSchema;
+
+			// Define new version with updated schema
+			this.version(this.currentVersion).stores(this.schema);
+
+			this.close();
+			this.open().catch((e) => console.error('Error reopening database:', e));
+
+			this.tablesMap[key] = this.table(key);
+		}
+
+		return this.tablesMap[key];
+	}
+
+	getTable(key: string): Table<any, string> {
+		return this.tablesMap[key];
+	}
+}

--- a/src/lib/storage/local-store.spec.ts
+++ b/src/lib/storage/local-store.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createLocalStore } from './local-store.svelte';
 
 vi.mock('$app/environment', () => ({
@@ -10,57 +11,72 @@ describe('createLocalStore', () => {
 		localStorage.clear();
 	});
 
-	it('should create store with initial value when localStorage is empty', () => {
+	it('should create store with initial value when localStorage is empty', async () => {
 		const store = createLocalStore('testKey', 'initial');
+
+		await new Promise((r) => setTimeout(r, 50)); // Wait for async operations
 
 		expect(store.value).toBe('initial');
 		expect(store.isLoaded).toBe(true);
 	});
 
-	it('should load existing value from localStorage', () => {
+	it('should load existing value from localStorage', async () => {
 		localStorage.setItem('testKey', JSON.stringify('stored value'));
 
 		const store = createLocalStore('testKey', 'initial');
+
+		await new Promise((r) => setTimeout(r, 50)); // Wait for async operations
 
 		expect(store.value).toBe('stored value');
 		expect(store.isLoaded).toBe(true);
 	});
 
-	it('should update localStorage when value changes', () => {
+	it('should update IndexedDB when value changes', async () => {
 		const store = createLocalStore('testKey', 'initial');
+
+		await new Promise((r) => setTimeout(r, 50));
 
 		store.value = 'new value';
 
-		expect(localStorage.getItem('testKey')).toBe(JSON.stringify('new value'));
 		expect(store.value).toBe('new value');
+		expect(await store.db.data.get('testKey')).toStrictEqual({
+			key: 'testKey',
+			value: 'new value'
+		});
 	});
 
-	it('should handle invalid JSON in localStorage', () => {
-		localStorage.setItem('testKey', 'invalid json');
-
+	it('should reset to initial value', async () => {
 		const store = createLocalStore('testKey', 'initial');
 
-		expect(store.value).toBe('initial');
-	});
+		await new Promise((r) => setTimeout(r, 50)); // Wait for async operations
 
-	it('should reset to initial value', () => {
-		const store = createLocalStore('testKey', 'initial');
 		store.value = 'changed';
 
 		store.reset();
 
 		expect(store.value).toBe('initial');
-		expect(localStorage.getItem('testKey')).toBe(JSON.stringify('initial'));
+		expect(await store.db.data.get('testKey')).toStrictEqual({
+			key: 'testKey',
+			value: 'initial'
+		});
 	});
 
-	it('should work with complex objects', () => {
+	it('should work with complex objects', async () => {
 		const initialValue = { foo: 'bar', num: 42 };
 		const store = createLocalStore('testKey', initialValue);
+
+		await new Promise((r) => setTimeout(r, 50)); // Wait for async operations
 
 		const newValue = { foo: 'baz', num: 43 };
 		store.value = newValue;
 
 		expect(store.value).toEqual(newValue);
-		expect(JSON.parse(localStorage.getItem('testKey') || '')).toEqual(newValue);
+		expect(await store.db.data.get('testKey')).toStrictEqual({
+			key: 'testKey',
+			value: {
+				foo: 'baz',
+				num: 43
+			}
+		});
 	});
 });

--- a/src/lib/storage/local-store.svelte.ts
+++ b/src/lib/storage/local-store.svelte.ts
@@ -84,7 +84,16 @@ export function createLocalStore<T>(
 		set value(newValue: T) {
 			value = newValue;
 			if (browser) {
-				db.data.put({ key, value: newValue }).catch(console.error);
+				db.data
+					.put({
+						key,
+						value: typeof newValue !== 'object' ? newValue : JSON.parse(JSON.stringify(newValue))
+					})
+					.catch('DataCloneError', (e) => {
+						// Failed with DataCloneError
+						console.error('DataClone error: ' + e.message);
+					})
+					.catch(console.error);
 			}
 		},
 		get isLoaded() {

--- a/src/lib/storage/local-store.svelte.ts
+++ b/src/lib/storage/local-store.svelte.ts
@@ -1,15 +1,33 @@
 import { browser } from '$app/environment';
+import Dexie from 'dexie';
 
 export interface LocalStore<T> {
 	value: T;
 	readonly isLoaded: boolean;
+	readonly db: AppDatabase;
 	reset(): void;
 }
 
+class AppDatabase extends Dexie {
+	data: Dexie.Table<{ key: string; value: any }, string>;
+
+	constructor() {
+		super('AppDatabase');
+
+		this.version(1).stores({
+			data: '&key' // Unique key index
+		});
+
+		this.data = this.table('data');
+	}
+}
+
+const db = new AppDatabase();
+
 /**
- * Creates a reactive local storage store with automatic persistence
- * @param key The localStorage key
- * @param initialValue The initial value if nothing is in localStorage
+ * Creates a reactive IndexedDB store with automatic persistence and migration from localStorage.
+ * @param key The IndexedDB key
+ * @param initialValue The initial value if nothing is stored
  * @param patchLoadedValue Optional function to patch loaded values with missing properties
  * @returns A store object
  */
@@ -21,18 +39,43 @@ export function createLocalStore<T>(
 	let value = $state<T>(initialValue);
 	let isLoaded = $state(false);
 
-	if (browser) {
-		const stored = localStorage.getItem(key);
-		if (stored) {
-			try {
-				const parsedValue = JSON.parse(stored);
-				value = patchLoadedValue ? patchLoadedValue(parsedValue, initialValue) : parsedValue;
-			} catch {
-				value = initialValue;
+	async function loadDatabase() {
+		if (!browser) return;
+
+		try {
+			// Step 1: Check for existing data in IndexedDB
+			const stored = await db.data.get(key);
+
+			if (stored && stored.value) {
+				value = patchLoadedValue ? patchLoadedValue(stored.value, initialValue) : stored.value;
+			} else {
+				// Step 2: Check localStorage for migration
+				const localStored = localStorage.getItem(key);
+
+				if (localStored) {
+					try {
+						const parsedValue = JSON.parse(localStored);
+						value = patchLoadedValue ? patchLoadedValue(parsedValue, initialValue) : parsedValue;
+
+						// Migrate the data to IndexedDB
+						await db.data.put({ key, value });
+
+						// Remove from localStorage after migration
+						localStorage.removeItem(key);
+					} catch {
+						value = initialValue;
+					}
+				}
 			}
+		} catch (error) {
+			console.error('Error loading data:', error);
+			value = initialValue;
+		} finally {
+			isLoaded = true;
 		}
-		isLoaded = true;
 	}
+
+	loadDatabase(); // Trigger the initial load asynchronously
 
 	const store = {
 		get value() {
@@ -41,11 +84,14 @@ export function createLocalStore<T>(
 		set value(newValue: T) {
 			value = newValue;
 			if (browser) {
-				localStorage.setItem(key, JSON.stringify(newValue));
+				db.data.put({ key, value: newValue }).catch(console.error);
 			}
 		},
 		get isLoaded() {
 			return isLoaded;
+		},
+		get db() {
+			return db;
 		},
 		reset() {
 			this.value = initialValue;

--- a/src/lib/stores/tours.ts
+++ b/src/lib/stores/tours.ts
@@ -41,6 +41,8 @@ export default {
 	},
 
 	isTourCompleted(tour: string, tourUpdateDate: Date): boolean {
+		if (!tourStore.isLoaded) return true
+
 		return (
 			this.completedTours.find(
 				(t) =>

--- a/src/lib/tours/airline-search.tour.ts
+++ b/src/lib/tours/airline-search.tour.ts
@@ -3,7 +3,7 @@ import type { Tour } from './types';
 export const airlineSearchTour: Tour = {
 	name: 'airlineSearch',
 	updatedAt: new Date('2025-02-03T00:00:00Z'),
-	steps: () => [
+	steps: [
 		{
 			popover: {
 				title: 'Quick Airline Search 🔍',

--- a/src/lib/tours/manage-favorites.tour.ts
+++ b/src/lib/tours/manage-favorites.tour.ts
@@ -3,7 +3,7 @@ import type { Tour } from './types';
 export const manageFavoritesTour: Tour = {
 	name: 'manageFavorites',
 	updatedAt: new Date('2025-02-07T00:00:00Z'),
-	steps: () => [
+	steps: [
 		{
 			popover: {
 				title: 'Favorite Airlines ⭐',

--- a/src/lib/tours/onboarding.tour.ts
+++ b/src/lib/tours/onboarding.tour.ts
@@ -3,7 +3,7 @@ import type { Tour } from './types';
 export const onboardingTour: Tour = {
 	name: 'onboarding',
 	updatedAt: new Date('2025-02-03T00:00:00Z'),
-	steps: () => [
+	steps: [
 		{
 			popover: {
 				title: 'Welcome to CarryFit! 🎉',

--- a/src/lib/tours/tour-runner.spec.ts
+++ b/src/lib/tours/tour-runner.spec.ts
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getActiveTours, MAIN_TOUR } from './active-tours';
 import tourStore from '$lib/stores/tours';
@@ -9,7 +10,7 @@ vi.mock('./active-tours', () => ({
 	MAIN_TOUR: {
 		name: 'main-tour',
 		updatedAt: new Date('2024-01-01'),
-		steps: () => []
+		steps: []
 	} satisfies Tour,
 	getActiveTours: vi.fn(),
 	exists: vi.fn().mockReturnValue(true)
@@ -31,17 +32,17 @@ describe('getPendingTours', () => {
 		expect(result).toEqual([]);
 	});
 
-	it('should filter out completed tours', () => {
+	it.only('should filter out completed tours', () => {
 		const mockTours: Tour[] = [
 			{
 				name: 'tour1',
 				updatedAt: new Date('2024-01-01'),
-				steps: () => []
+				steps: []
 			},
 			{
 				name: 'tour2',
 				updatedAt: new Date('2024-01-01'),
-				steps: () => []
+				steps: []
 			}
 		];
 
@@ -65,7 +66,7 @@ describe('getPendingTours', () => {
 			{
 				name: 'feature-tour',
 				updatedAt: new Date('2024-01-01'),
-				steps: () => []
+				steps: []
 			}
 		];
 
@@ -83,7 +84,7 @@ describe('getPendingTours', () => {
 			{
 				name: 'feature-tour',
 				updatedAt: new Date('2024-01-01'),
-				steps: () => []
+				steps: []
 			}
 		];
 

--- a/src/lib/tours/tour-runner.spec.ts
+++ b/src/lib/tours/tour-runner.spec.ts
@@ -32,7 +32,7 @@ describe('getPendingTours', () => {
 		expect(result).toEqual([]);
 	});
 
-	it.only('should filter out completed tours', () => {
+	it('should filter out completed tours', () => {
 		const mockTours: Tour[] = [
 			{
 				name: 'tour1',

--- a/src/lib/tours/tour-runner.svelte.ts
+++ b/src/lib/tours/tour-runner.svelte.ts
@@ -72,7 +72,7 @@ function showTour(tour: Tour, force = false, onDestroyed?: () => void) {
 		return;
 	}
 
-	const driver = createDriver(tour.name, tour.steps(), onDestroyed);
+	const driver = createDriver(tour.name, tour.steps, onDestroyed);
 	driver.drive();
 
 	metrics.tourShown(tour.name);

--- a/src/lib/tours/types.ts
+++ b/src/lib/tours/types.ts
@@ -8,6 +8,6 @@ export const TOURS = {
 
 export interface Tour {
 	name: string;
-	steps: () => DriveStep[];
+	steps: DriveStep[];
 	updatedAt: Date;
 }


### PR DESCRIPTION
## Ticket
Issue: https://github.com/AxelUser/carry-fit/issues/63

## Description

Currently, our application uses localStorage for managing various stores such as preferences, tours and etc. While localStorage is simple to use, it lacks the flexibility needed for schema migrations and efficient handling of complex data structures, which are often stored as JSON.

## TODO

- [x] Replace createLocalStore with a new utility function that leverages Dexie.js for store creation.
- [x] Update all store implementations in the src/lib/stores/ directory to use the new IndexedDB-based store. _With the current refactor was not need_
- [x] Ensure backward compatibility by migrating existing data from localStorage to IndexedDB on the first run after the update.
- [ ] Implement schema versioning to handle future data structure changes seamlessly.